### PR TITLE
第12章の内容

### DIFF
--- a/app/assets/javascripts/password_resets.coffee
+++ b/app/assets/javascripts/password_resets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,6 +2,19 @@ class PasswordResetsController < ApplicationController
   def new
   end
 
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "Email sent with password reset instructions"
+      redirect_to root_url
+    else
+      flash.now[:danger] = "Email address not found"
+      render 'new'
+    end
+  end
+
   def edit
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,7 @@
+class PasswordResetsController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,7 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+
   def new
   end
 
@@ -17,4 +20,15 @@ class PasswordResetsController < ApplicationController
 
   def edit
   end
+
+  private
+    def get_user
+      @user = User.find_by(email: params[:email])
+    end
+
+    def valid_user
+      unless (@user && @user.activated? && @user.authenticated?(:reset, params[:id]))
+        redirect_to root_url
+      end
+    end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,6 +1,7 @@
 class PasswordResetsController < ApplicationController
   before_action :get_user, only: [:edit, :update]
   before_action :valid_user, only: [:edit, :update]
+  before_action :check_expiration, only: [:edit, :update]
 
   def new
   end
@@ -21,7 +22,26 @@ class PasswordResetsController < ApplicationController
   def edit
   end
 
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, :blank)
+      render 'edit'
+    elsif @user.update_attributes(user_params)
+      log_in @user
+      @user.update_attribute(:reset_digest, nil)
+      flash[:success] = "Password has been reset."
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
   private
+
+    def user_params
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+
     def get_user
       @user = User.find_by(email: params[:email])
     end
@@ -31,4 +51,12 @@ class PasswordResetsController < ApplicationController
         redirect_to root_url
       end
     end
+
+    def check_expiration
+      if @user.password_reset_expired?
+        flash[:danger] = "Password reset has expired."
+        redirect_to new_password_reset_url
+      end
+    end
+
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -58,5 +58,4 @@ class PasswordResetsController < ApplicationController
         redirect_to new_password_reset_url
       end
     end
-
 end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,9 +15,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def password_reset(user)
+    @user = user
+    mail to:user.email, subject: "Password reset"
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,20 +1,9 @@
 class UserMailer < ApplicationMailer
-
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.user_mailer.account_activation.subject
-  #
   def account_activation(user)
     @user = user
     mail to: user.email, subject: "Account activation"
   end
 
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.user_mailer.password_reset.subject
-  #
   def password_reset(user)
     @user = user
     mail to:user.email, subject: "Password reset"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
   validates :name,  presence: true, length: { maximum: 50 }
@@ -49,6 +49,18 @@ class User < ApplicationRecord
   # 有効化用のメールを送信
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_attribute(:reset_digest, User.digest(reset_token))
+    update_attribute(:reset_sent_at, Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,13 +54,16 @@ class User < ApplicationRecord
   # パスワード再設定の属性を設定
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attribute(:reset_digest, User.digest(reset_token))
-    update_attribute(:reset_sent_at, Time.zone.now)
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
   end
 
   # パスワード再設定のメールを送信
   def send_password_reset_email
     UserMailer.password_reset(self).deliver_now
+  end
+
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,20 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<% provide(:title, 'Reset password') %>
+<h1>Reset password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render  "shared/error_messages" %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Update password", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#new</h1>
+<p>Find me in app/views/password_resets/new.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,2 +1,13 @@
-<h1>PasswordResets#new</h1>
-<p>Find me in app/views/password_resets/new.html.erb</p>
+<% provide(:title, "Forgot password") %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(:password_reset, url: password_resets_path) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,6 +9,7 @@
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
+      <%= link_to  "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,13 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token,
+                                                      email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,8 @@
-User#password_reset
+To reset your password click the link below:
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
-  get 'password_resets/new'
-
-  get 'password_resets/edit'
-
   root 'static_pages#home'
+  get 'password_resets/new'
+  get 'password_resets/edit'
   get  '/help',      to: 'static_pages#help'
   get  '/about',     to: 'static_pages#about'
   get  '/contact',   to: 'static_pages#contact'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
   delete '/logout',  to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
-  resources :password_results, only: [:new, :create, :edit, :update]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  get 'password_resets/new'
+
+  get 'password_resets/edit'
+
   root 'static_pages#home'
   get  '/help',      to: 'static_pages#help'
   get  '/about',     to: 'static_pages#about'
@@ -10,4 +14,5 @@ Rails.application.routes.draw do
   delete '/logout',  to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_results, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20170710063013_add_reset_to_users.rb
+++ b/db/migrate/20170710063013_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706085219) do
+ActiveRecord::Schema.define(version: 20170710063013) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 20170706085219) do
     t.string   "activation_digest"
     t.boolean  "activated",         default: false
     t.datetime "activated_at"
+    t.string   "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -67,7 +67,7 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     @user.update_attribute(:reset_sent_at, 3.hours.ago)
     patch password_reset_path(@user.reset_token),
           params: { email: @user.email,
-               user: {password: "foobar", password_confirmation: "foobar" } }
+                    user: {password: "foobar", password_confirmation: "foobar" } }
     assert_response :redirect
     follow_redirect!
     assert_match "expired",response.body

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -6,36 +6,57 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     @user = users(:michael)
   end
 
-  test "password resets" do
+  test "invalid email information in password resets new page" do
     get new_password_reset_path
     assert_template 'password_resets/new'
-    # メールアドレスが無効
     post password_resets_path, params: { password_reset: { email: "" } }
     assert_not flash.empty?
     assert_template 'password_resets/new'
-    #メールアドレスが有効
+  end
+
+ test "valid email information in password resets new page" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
     post password_resets_path, params: { password_reset: { email: @user.email } }
     assert_not_equal @user.reset_digest, @user.reload.reset_digest
     assert_equal 1, ActionMailer::Base.deliveries.size
     assert_not flash.empty?
     assert_redirected_to root_url
-    # パスワード再設定フォームテスト
+  end
+
+  test "should redirect to root" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    post password_resets_path, params: { password_reset: { email: @user.email } }
     user = assigns(:user)
-    # メールアドレスが無効
+    # 無効なメールアドレスで要求された時
     get edit_password_reset_path(user.reset_token, email: "")
     assert_redirected_to root_url
-    # 無効なユーザー
+    # 無効なユーザに要求された時
     user.toggle!(:activated)
     get edit_password_reset_path(user.reset_token, email: user.email)
     assert_redirected_to root_url
-    user.toggle!(:activated)
-    # メールアドレスが有効で、トークンが無効
+    # 無効なトークンで要求された時
     get edit_password_reset_path('wrong token', email: user.email)
     assert_redirected_to root_url
-    # メールアドレスもトークンも有効
+  end
+
+  test "redirect to password reset edit page" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    post password_resets_path, params: { password_reset: { email: @user.email } }
+    user = assigns(:user)
     get edit_password_reset_path(user.reset_token, email: user.email)
     assert_template 'password_resets/edit'
     assert_select "input[name=email][type=hidden][value=?]", user.email
+  end
+
+  test "invalid password update information" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    post password_resets_path, params: { password_reset: { email: @user.email } }
+    user = assigns(:user)
+    get edit_password_reset_path(user.reset_token, email: user.email)
     # 無効なパスワードとパスワード確認
     patch password_reset_path(user.reset_token),
           params: { email: user.email,
@@ -48,7 +69,14 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
                     user: { password:              "",
                             password_confirmation: "" } }
     assert_select 'div#error_explanation'
-    # 有効なパスワードとパスワード確認
+  end
+
+  test "valid password update information" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    post password_resets_path, params: { password_reset: { email: @user.email } }
+    user = assigns(:user)
+    get edit_password_reset_path(user.reset_token, email: user.email)
     patch password_reset_path(user.reset_token),
           params: { email: user.email,
                     user: { password:              "foobaz",

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class PasswordResetsTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @user = users(:michael)
+  end
+
+  test "password resets" do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    # メールアドレスが無効
+    post password_resets_path, params: { password_reset: { email: "" } }
+    assert_not flash.empty?
+    assert_template 'password_resets/new'
+    #メールアドレスが有効
+    post password_resets_path, params: { password_reset: { email: @user.email } }
+    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+    # パスワード再設定フォームテスト
+    user = assigns(:user)
+    # メールアドレスが無効
+    get edit_password_reset_path(user.reset_token, email: "")
+    assert_redirected_to root_url
+    # 無効なユーザー
+    user.toggle!(:activated)
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_redirected_to root_url
+    user.toggle!(:activated)
+    # メールアドレスが有効で、トークンが無効
+    get edit_password_reset_path('wrong token', email: user.email)
+    assert_redirected_to root_url
+    # メールアドレスもトークンも有効
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_template 'password_resets/edit'
+    assert_select "input[name=email][type=hidden][value=?]", user.email
+    # 無効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "foobaz",
+                            password_confirmation: "barquux" } }
+    assert_select 'div#error_explanation'
+    # パスワードが空
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "",
+                            password_confirmation: "" } }
+    assert_select 'div#error_explanation'
+    # 有効なパスワードとパスワード確認
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                    user: { password:              "foobaz",
+                            password_confirmation: "foobaz" } }
+    assert is_logged_in?
+    assert_nil user.reload.reset_digest
+    assert_not flash.empty?
+    assert_redirected_to user
+  end
+
+  test "expired token" do
+    get new_password_reset_path
+    post password_resets_path,
+          params: { password_reset: { email: @user.email } }
+    @user = assigns(:user)
+    @user.update_attribute(:reset_sent_at, 3.hours.ago)
+    patch password_reset_path(@user.reset_token),
+          params: { email: @user.email,
+               user: {password: "foobar", password_confirmation: "foobar" } }
+    assert_response :redirect
+    follow_redirect!
+    assert_match "expired",response.body
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -10,7 +10,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -12,4 +12,15 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match user.activation_token, mail.body.encoded
     assert_match CGI.escape(user.email), mail.body.encoded
   end
+
+  test "password_reset" do
+    user = users(:michael)
+    user.reset_token = User.new_token
+    mail = UserMailer.password_reset(user)
+    assert_equal "Password reset", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.reset_token, mail.body.encoded
+    assert_match CGI.escape(user.email), mail.body.encoded
+  end
 end


### PR DESCRIPTION
## 概要
ユーザがパスワードを忘れた時のためにパスワードリセット機能を実装
[rails tutorial 第12章](https://railstutorial.jp/chapters/password_reset?version=5.0#cha-password_reset)

## 詳細
- パスワードリセットのためのリソースを追加
- ログイン画面にパスワードリセット（fogot password）を追加
- パスワードリセットのトークンを送信するためのメール機能を追加
- パスワードリセットの処理を追加

## レビューポイント
- password_resetsのcontrollerとview周りの実装
- password_resets実装にあたってのuserモデルの変更