### PR TITLE
CapでPumaの起動、再起動、停止タスクを記述

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,3 +11,15 @@ task :start do
     execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec puma"
   end
 end
+
+task :stop do
+  on roles(:web) do
+    execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec pumactl stop"
+  end
+end
+
+task :restart do
+  on roles(:web) do
+    execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec pumactl restart"
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,13 +8,13 @@ set :rails_env, 'production'
 
 task :start do
   on roles(:web) do
-    execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec puma"
+    execute "systemctl start puma"
   end
 end
 
 task :stop do
   on roles(:web) do
-    execute "cd /var/www/sample_app/current/ && bundle exec pumactl stop"
+    execute "systemctl stop puma"
   end
 end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,12 +14,12 @@ end
 
 task :stop do
   on roles(:web) do
-    execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec pumactl stop"
+    execute "cd /var/www/sample_app/current/ && bundle exec pumactl stop"
   end
 end
 
 task :restart do
   on roles(:web) do
-    execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec pumactl restart"
+    execute "cd /var/www/sample_app/current/ && bundle exec pumactl restart"
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@ lock "3.9.0"
 
 set :application, "sample_app"
 set :repo_url, "https://github.com/Komei22/sample_app.git"
-set :branch, "master"
+set :branch, "cap-start-puma"
 set :rails_env, 'production'
 
 task :start do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,23 +3,23 @@ lock "3.9.0"
 
 set :application, "sample_app"
 set :repo_url, "https://github.com/Komei22/sample_app.git"
-set :branch, "cap-start-puma"
+set :branch, "master"
 set :rails_env, 'production'
 
 task :start do
   on roles(:web) do
-    execute "systemctl start puma"
+    execute "sudo systemctl start puma"
   end
 end
 
 task :stop do
   on roles(:web) do
-    execute "systemctl stop puma"
+    execute "sudo systemctl stop puma"
   end
 end
 
 task :restart do
   on roles(:web) do
-    execute "cd /var/www/sample_app/current/ && bundle exec pumactl restart"
+    execute "sudo systemctl restart puma"
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,8 @@ set :repo_url, "https://github.com/Komei22/sample_app.git"
 set :branch, "master"
 set :rails_env, 'production'
 
-task :deploy do
+task :start do
   on roles(:web) do
+    execute "cd /var/www/sample_app/current/ && RACK_ENV=production bundle exec puma"
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@ lock "3.9.0"
 
 set :application, "sample_app"
 set :repo_url, "https://github.com/Komei22/sample_app.git"
-set :branch, "cap-start-puma"
+set :branch, "master"
 set :rails_env, 'production'
 
 task :start do

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -2,6 +2,8 @@ workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
 
+pidfile "/var/tmp/puma.pid"
+
 preload_app!
 
 rackup      DefaultRackup

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,6 +7,7 @@ preload_app!
 rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
+daemonize true
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,6 @@ preload_app!
 rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
-daemonize true
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+


### PR DESCRIPTION
### 何を解決するのか
- CapをつかってPumaサーバの起動・再起動・停止を行えるようになる
```
# 起動
$ cap production start
# 停止
$ cap production stop
# 再起動
$ cap production restart
```

### 詳細
- 起動・再起動・停止タスクを記述
- pidfileを `/var/tmp` に設定


### レビューポイント
- `config/puma.rb`
    - pidfileまわり
- `config/deploy.rb`
    - 各タスクの記述