### PR TITLE
mysqlサーバに外部接続できるようにする。

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,5 +19,7 @@ test:
 
 production:
   <<: *default
+  host: db
   database: rails_production
-  url: mysql2://<%= ENV["DB_USER_NAME"] %>:<%= ENV["DB_PASS"] %>@db:3306
+  username: <%= ENV["DB_USER_NAME"] %>
+  password: <%= ENV["DB_PASS"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,16 +2,17 @@ default: &default
   adapter: mysql2
   encoding: utf8
   pool: 5
-  host: localhost
 
 development:
   <<: *default
+  host: localhost
   database: rails_development
   username: rails_app
   password: rails_app
 
 test:
   <<: *default
+  host: localhost
   database: rails_development
   username: rails_app
   password: rails_app
@@ -19,5 +20,4 @@ test:
 production:
   <<: *default
   database: rails_production
-  username: <%= ENV["DB_USER_NAME"] %>
-  password: <%= ENV["DB_PASS"] %>
+  url: mysql2://<%= ENV["DB_USER_NAME"] %>:<%= ENV["DB_PASS"] %>@db:3306

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,24 +2,21 @@ default: &default
   adapter: mysql2
   encoding: utf8
   pool: 5
+  username: <%= ENV["DB_USER_NAME"] %>
+  password: <%= ENV["DB_PASS"] %>
 
 development:
   <<: *default
   host: localhost
   database: rails_development
-  username: rails_app
-  password: rails_app
 
 test:
   <<: *default
   host: localhost
   database: rails_development
-  username: rails_app
-  password: rails_app
+
 
 production:
   <<: *default
   host: db
   database: rails_production
-  username: <%= ENV["DB_USER_NAME"] %>
-  password: <%= ENV["DB_PASS"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,21 +2,21 @@ default: &default
   adapter: mysql2
   encoding: utf8
   pool: 5
-  username: <%= ENV["DB_USER_NAME"] %>
-  password: <%= ENV["DB_PASS"] %>
+  host: localhost
+  database: rails_development
+  username: rails_app
+  password: rails_app
+
 
 development:
   <<: *default
-  host: localhost
-  database: rails_development
 
 test:
   <<: *default
-  host: localhost
-  database: rails_development
-
 
 production:
   <<: *default
   host: db
   database: rails_production
+  username: <%= ENV["DB_USER_NAME"] %>
+  password: <%= ENV["DB_PASS"] %>


### PR DESCRIPTION
### 何を解決するのか

`rails db:setup`時にmysqlサーバに外部アクセスして`database`を立てれるようにした。

### 詳細

`database.yml`の`production`の設定に`url`の項目を追加した。

```
production:
  <<: *default
  host: db
  database: rails_production
  username: <%= ENV["DB_USER_NAME"] %>
  password: <%= ENV["DB_PASS"] %>
```


従って`rails db:setup`時に以下のコマンドを実行して環境定数設定を事前に行う。　
環境定数を設定後は`rails db:setup`を実行する事で外部のmysqlサーバに`production`のdatabaseが作られる。
 

```
export RAILS_ENV=production DB_USER_NAME=hoge DB_PASS='fuga'
rails db:setup
```


### レビュー

こうめい。がっちゃん。