### PR TITLE
hostを指定する為の環境定数を追加する。

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,7 @@ test:
 
 production:
   <<: *default
-  host: db
+  host: 10.51.107.11
   database: rails_production
   username: <%= ENV["DB_USER_NAME"] %>
   password: <%= ENV["DB_PASS"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,7 @@ test:
 
 production:
   <<: *default
-  host: <%= ENV["host"] %>
+  host: <%= ENV["DB_HOST"] %>
   database: rails_production
   username: <%= ENV["DB_USER_NAME"] %>
   password: <%= ENV["DB_PASS"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,7 @@ test:
 
 production:
   <<: *default
-  host: 10.51.107.11
+  host: <%= ENV["host"] %>
   database: rails_production
   username: <%= ENV["DB_USER_NAME"] %>
   password: <%= ENV["DB_PASS"] %>


### PR DESCRIPTION
### 何を解決するのか

`production環境`での`rails db:setup`実行時のdbインスタンスのhostを指定します。

### 詳細

Nyah上のdbインスタンスのipアドレスは`10.51.107.11`となっており、その値をdatabase.yml上で指定しています。


### レビューポイント

- `database.yml`
  - 変更が正しいか。

### レビュアー

がっちゃん、こうめい
