### PR TITLE
Micropostを投稿するAPIを実装

### DIFF
--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -16,13 +16,13 @@ class MicropostsController < ApplicationController
 
   def create_without_auth
     user = User.find_by(id: params[:user_id])
-    if user
-      @micropost = user.microposts.build(micropost_params)
+    render "microposts/errors/user_not_found" and return if user.nil?
+    @micropost = user.microposts.build(micropost_params)
+
     #   if @micropost.save
     #   else
     #     # 保存できなかったときの処理
     #   end
-    end
   end
 
   def destroy

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -1,6 +1,7 @@
 class MicropostsController < ApplicationController
   before_action :logged_in_user, only: [:create, :destroy]
   before_action :correct_user, only: :destroy
+  protect_from_forgery except: [:create_without_auth]
 
   def create
     @micropost = current_user.microposts.build(micropost_params)
@@ -13,14 +14,14 @@ class MicropostsController < ApplicationController
     end
   end
 
-  def create_by_api
-    user = User.find_by(id: prams[:user_id])
+  def create_without_auth
+    user = User.find_by(id: params[:user_id])
     if user
       @micropost = user.microposts.build(micropost_params)
-      if @micropost.save
-      else
-        # 保存できなかったときの処理
-      end
+    #   if @micropost.save
+    #   else
+    #     # 保存できなかったときの処理
+    #   end
     end
   end
 

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -18,11 +18,7 @@ class MicropostsController < ApplicationController
     user = User.find_by(id: params[:user_id])
     render "microposts/errors/user_not_found" and return if user.nil?
     @micropost = user.microposts.build(micropost_params)
-
-    #   if @micropost.save
-    #   else
-    #     # 保存できなかったときの処理
-    #   end
+    render "microposts/errors/could_not_saved" and return unless @micropost.save
   end
 
   def destroy

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -13,6 +13,9 @@ class MicropostsController < ApplicationController
     end
   end
 
+  def create_by_api
+  end
+
   def destroy
     @micropost.destroy
     flash[:success] = "Micropost deleted"

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -14,6 +14,14 @@ class MicropostsController < ApplicationController
   end
 
   def create_by_api
+    user = User.find_by(id: prams[:user_id])
+    if user
+      @micropost = user.microposts.build(micropost_params)
+      if @micropost.save
+      else
+        # 保存できなかったときの処理
+      end
+    end
   end
 
   def destroy

--- a/app/views/microposts/create_without_auth.json.jbuilder
+++ b/app/views/microposts/create_without_auth.json.jbuilder
@@ -1,0 +1,1 @@
+json.micropost @micropost

--- a/app/views/microposts/errors/could_not_saved.json.jbuilder
+++ b/app/views/microposts/errors/could_not_saved.json.jbuilder
@@ -1,5 +1,4 @@
 json.error do
   json.message "Posted micropost could not saved for database"
-  json.reason "Maybe your micropost is over 140 charactors"
   json.code 500
 end

--- a/app/views/microposts/errors/could_not_saved.json.jbuilder
+++ b/app/views/microposts/errors/could_not_saved.json.jbuilder
@@ -1,0 +1,5 @@
+json.error do
+  json.message "Posted micropost could not saved for database"
+  json.reason "Maybe your micropost is over 140 charactors"
+  json.code 500
+end

--- a/app/views/microposts/errors/user_not_found.json.jbuilder
+++ b/app/views/microposts/errors/user_not_found.json.jbuilder
@@ -1,4 +1,4 @@
 json.error do
   json.message "user_id:#{params[:user_id]} not found"
-  json.code "400"
+  json.code 404
 end

--- a/app/views/microposts/errors/user_not_found.json.jbuilder
+++ b/app/views/microposts/errors/user_not_found.json.jbuilder
@@ -1,0 +1,4 @@
+json.error do
+  json.message "user_id:#{params[:user_id]} not found"
+  json.code "400"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,12 +21,16 @@ Rails.application.routes.draw do
   resources :microposts, only: [:create, :destroy]
   resources :relationships, only: [:create, :destroy]
 
-  # ユーザ情報API用のエンドポイントを定義
   scope '/api', { format: 'json' } do
     resources :users do
       member do
         get :profile, to: 'users#user_info'
         get :microposts, to: 'users#user_microposts'
+      end
+    end
+    resources :microposts do
+      member do
+        post :update, to: 'microposts#create_by_api'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,10 +28,8 @@ Rails.application.routes.draw do
         get :microposts, to: 'users#user_microposts'
       end
     end
-    resources :microposts do
-      member do
-        post :update, to: 'microposts#create_by_api'
-      end
-    end
+
+    post 'microposts/create', to: 'microposts#create_without_auth'
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,5 @@ Rails.application.routes.draw do
     end
 
     post 'microposts/create', to: 'microposts#create_without_auth'
-
   end
 end

--- a/test/integration/microposts_create_test.rb
+++ b/test/integration/microposts_create_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class MicropostsCreateTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+  end
+
+  test "show json when micropost create" do
+    content = "hogehoge"
+    assert_difference 'Micropost.count', 1 do
+      post microposts_create_path, params: { user_id: @user.id, micropost: { content: content} }
+    end
+    assert_match "micropost", response.body
+    assert_match "id", response.body
+    assert_match "content", response.body
+    assert_match "user_id", response.body
+    assert_match "created_at", response.body
+    assert_match "updated_at", response.body
+    assert_match "picture", response.body
+  end
+
+  test "show error json when micropost could not saved" do
+    content = "hoge" * 50
+    assert_no_difference 'Micropost.count' do
+      post microposts_create_path, params: { user_id: @user.id, micropost: { content: content} }
+    end
+    assert_match "error", response.body
+    assert_match "message", response.body
+    assert_match "code", response.body
+    assert_match "500", response.body
+  end
+
+  test "show error json when user is not found" do
+    content = "hoge"
+    assert_no_difference 'Micropost.count' do
+      post microposts_create_path, params: { user_id: 1000, micropost: { content: content} }
+    end
+    assert_match "error", response.body
+    assert_match "message", response.body
+    assert_match "code", response.body
+    assert_match "404", response.body
+  end
+end


### PR DESCRIPTION
### 何を解決するのか

- MicropostをAPIから投稿できるようになる

#### 仕様
- エンドポイント
    - http://piyorin.xyz/api/microposts/create
- 利用できるパラメータ
    - user_id：ユーザのID
    - micropost[content]：postするテキスト
- レスポンス
```
$ curl -X POST -d 'user_id=1&micropost[content]=fugafuga' http://localhost:3000/api/microposts/create | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   207    0   170  100    37    578    125 --:--:-- --:--:-- --:--:--   580
{
  "micropost": {
    "id": 301,
    "content": "fugafuga",
    "user_id": 1,
    "created_at": "2017-10-11T17:31:24.000+09:00",
    "updated_at": "2017-10-11T17:31:24.000+09:00",
    "picture": {
      "url": null
    }
  }
}
```

### 詳細

- `microposts_controller.rb`
    - 認証無しでMicropostを投稿するためのアクションを追加
    - このアクションのみCSRF対策を外している
        - 今後ログイン機能を実装した段階でこのアクションは見直す必要あり
- レスポンスを返却するためのビュー
    - `create_without_auth.json.jbuilder`
        - 正常にMicropostを投稿したときに返却される
    - `could_not_saved.json.jbuilder`
        - Micropostをデータベースに登録できなかったときに返却される
    -  `user_not_found.json.jbuilder`
        - 指定したユーザが存在しなかったときに返却される

### レビューポイント

- エンドポイントは適切か
- `microposts_controller.rb`の処理は適切か
- 返却しているjsonは適切か

### レビュアー

@Fendo181 @Asuforce 

### 期限

なる速でお願いします！
