### PR TITLE
gravatarのサイズが変更できない問題を修正

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,10 +1,10 @@
 module UsersHelper
   # 引数で与えられたユーザのGravatarを返す
   def gravatar_for(user, size: 80)
-    image_tag(gravatar_url(user, size), alt: user.name, class: "gravatar")
+    image_tag(gravatar_url(user, size: size), alt: user.name, class: "gravatar")
   end
 
-  def gravatar_url(user, size)
+  def gravatar_url(user, size: 80)
     id = Digest::MD5::hexdigest(user.email.downcase)
     "https://secure.gravatar.com/avatar/#{id}?s=#{size}"
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,10 +1,10 @@
 module UsersHelper
   # 引数で与えられたユーザのGravatarを返す
   def gravatar_for(user, size: 80)
-    image_tag(gravatar_url(user), alt: user.name, class: "gravatar")
+    image_tag(gravatar_url(user, size), alt: user.name, class: "gravatar")
   end
 
-  def gravatar_url(user, size: 80)
+  def gravatar_url(user, size)
     id = Digest::MD5::hexdigest(user.email.downcase)
     "https://secure.gravatar.com/avatar/#{id}?s=#{size}"
   end

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class UsersHelperTest < ActionView::TestCase
+
+  def setup
+    @user = users(:michael)
+  end
+
+  test "gravatar image size should change 50" do
+    img_tag = gravatar_for(@user, size: 50)
+    assert_match "s=50", img_tag
+  end
+end


### PR DESCRIPTION
### 何を解決するか
- gravatarのサイズが変更できない問題を修正
- それにともなってレイアウトが崩れる問題を修正

### レビューポイント
- gravatarのurlを生成している処理
- users_helperのテスト

### レビュワー
@Fendo181