### PR TITLE
利用するデータベースをdevelopmentとtestで分けるように変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,16 +3,17 @@ default: &default
   encoding: utf8
   pool: 5
   host: localhost
-  database: rails_development
   username: rails_app
   password: rails_app
 
 
 development:
   <<: *default
+  database: rails_development
 
 test:
   <<: *default
+  database: rails_test
 
 production:
   <<: *default


### PR DESCRIPTION
### 何を解決するか
developmentとtestで利用するデータベースが分けられていないため、テストが走るたびにデータベースの内容がテストデータに書き換えられる現象を修正

### レビューポイント
databaseの設定

### レビュワー
@Fendo181 