### PR TITLE
Micropostモデルの文字数制限を拡張

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -3,7 +3,7 @@ class Micropost < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
   mount_uploader :picture, PictureUploader
   validates :user_id, presence: true
-  validates :content, presence: true, length: { maximum: 140 }
+  validates :content, presence: true, length: { maximum: 300 }
   validate :picture_size
 
   private

--- a/test/integration/microposts_create_test.rb
+++ b/test/integration/microposts_create_test.rb
@@ -21,7 +21,7 @@ class MicropostsCreateTest < ActionDispatch::IntegrationTest
   end
 
   test "show error json when micropost could not saved" do
-    content = "hoge" * 50
+    content = "a" * 301
     assert_no_difference 'Micropost.count' do
       post microposts_create_path, params: { user_id: @user.id, micropost: { content: content} }
     end

--- a/test/models/micropost_test.rb
+++ b/test/models/micropost_test.rb
@@ -20,8 +20,8 @@ class MicropostTest < ActiveSupport::TestCase
     assert_not @micropost.valid?
   end
 
-  test "content should be at most 140 characters" do
-    @micropost.content = "a" * 141
+  test "content should be at most 300 characters" do
+    @micropost.content = "a" * 301
     assert_not @micropost.valid?
   end
 


### PR DESCRIPTION
### 何を解決するのか
- モバイル側からのPOSTリクエストの関係で、要求されるMicropostの文字数を拡張する必要が出てきた。
- モバイル側からのリクエストに対応できるようになる

### 詳細
- `Micropost.rb`
    - MicropostモデルのContentのサイズを修正
- Micropostモデルの変更に伴ってテストを修正

### レビュワー
@Fendo181 @Asuforce